### PR TITLE
CommentSourcedTest hangs after first `entity.doTest1()`. Still debugging

### DIFF
--- a/src/test/java/io/vlingo/lattice/model/sourcing/CommandSourcedTest.java
+++ b/src/test/java/io/vlingo/lattice/model/sourcing/CommandSourcedTest.java
@@ -9,13 +9,14 @@ package io.vlingo.lattice.model.sourcing;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import io.vlingo.actors.World;
-import io.vlingo.actors.testkit.TestUntil;
+import io.vlingo.actors.testkit.AccessSafely;
 import io.vlingo.lattice.model.sourcing.SourcedTypeRegistry.Info;
 import io.vlingo.symbio.store.journal.Journal;
 import io.vlingo.symbio.store.journal.inmemory.InMemoryJournalActor;
@@ -30,30 +31,61 @@ public class CommandSourcedTest {
 
   @Test
   public void testThatCtorEmits() {
-    result.until = TestUntil.happenings(1);
+    System.out.println("testThatCtorEmits >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+    try {
+      
+    final AccessSafely access = result.afterCompleting(1);
+    
     entity.doTest1();
-    result.until.completes();
-    assertTrue(result.tested1);
-    assertEquals(1, result.applied.size());
-    assertEquals(DoCommand1.class, result.applied.get(0).getClass());
-    assertFalse(result.tested2);
+    
+    System.out.println("access.totalWrites=" + access.totalWrites());
+    
+    assertTrue(access.readFrom("tested1"));
+    assertEquals(1, (int) access.readFrom("appliedCount"));
+    Object appliedAt0 = access.readFrom("appliedAt", 0);
+    assertNotNull(appliedAt0);
+    assertEquals(DoCommand1.class, appliedAt0.getClass());
+    assertFalse(access.readFrom("tested2"));
+    
+    }
+    finally {
+      System.out.println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< testThatCtorEmits");
+    }
   }
 
   @Test
   public void testThatEventEmits() {
-    result.until = TestUntil.happenings(1);
+    System.out.println("testThatEventEmits >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+    try {
+    
+    final AccessSafely access = result.afterCompleting(1);
+    
     entity.doTest1();
-    result.until.completes();
-    assertTrue(result.tested1);
-    assertFalse(result.tested2);
-    assertEquals(1, result.applied.size());
-    assertEquals(DoCommand1.class, result.applied.get(0).getClass());
-    result.until = TestUntil.happenings(1);
+
+    System.out.println("access.totalWrites=" + access.totalWrites());
+
+    assertTrue(access.readFrom("tested1"));
+    assertFalse(access.readFrom("tested2"));
+    assertEquals(1, (int) access.readFrom("appliedCount"));
+    Object appliedAt0 = access.readFrom("appliedAt", 0);
+    assertNotNull(appliedAt0);
+    assertEquals(DoCommand1.class, appliedAt0.getClass());
+    
+    final AccessSafely access2 = result.afterCompleting(1);
+    
     entity.doTest2();
-    result.until.completes();
-    assertEquals(2, result.applied.size());
-    System.out.println("APPLIED: " + result.applied);
-    assertEquals(DoCommand2.class, result.applied.get(1).getClass());
+
+    System.out.println("access2.totalWrites=" + access2.totalWrites());
+
+    assertEquals(2, (int) access2.readFrom("appliedCount"));
+    Object appliedAt1 = access2.readFrom("appliedAt", 1);
+    assertNotNull(appliedAt1);
+    assertEquals(DoCommand2.class, appliedAt1.getClass());
+    
+    }
+    finally {
+      System.out.println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< testThatEventEmits");
+    }
   }
 
   @Before

--- a/src/test/java/io/vlingo/lattice/model/sourcing/EventSourcedTest.java
+++ b/src/test/java/io/vlingo/lattice/model/sourcing/EventSourcedTest.java
@@ -9,14 +9,16 @@ package io.vlingo.lattice.model.sourcing;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import io.vlingo.actors.World;
-import io.vlingo.actors.testkit.TestUntil;
+import io.vlingo.actors.testkit.AccessSafely;
 import io.vlingo.lattice.model.sourcing.SourcedTypeRegistry.Info;
+import io.vlingo.symbio.Entry;
 import io.vlingo.symbio.store.journal.Journal;
 import io.vlingo.symbio.store.journal.inmemory.InMemoryJournalActor;
 
@@ -30,58 +32,89 @@ public class EventSourcedTest {
 
   @Test
   public void testThatCtorEmits() {
-    result.until = TestUntil.happenings(1);
+    final AccessSafely resultAccess = result.afterCompleting(1);
+    final AccessSafely listenerAccess = listener.afterCompleting(1);
+
     entity.doTest1();
-    result.until.completes();
-    assertTrue(result.tested1);
-    assertEquals(1, result.applied.size());
-    assertEquals(1, listener.entries.size());
-    assertEquals(Test1Happened.class, result.applied.get(0).getClass());
-    assertEquals(Test1Happened.class.getName(), listener.entries.get(0).type);
-    assertFalse(result.tested2);
+    
+    assertTrue(resultAccess.readFrom("tested1"));
+    assertEquals(1, (int) resultAccess.readFrom("appliedCount"));
+    assertEquals(1, (int) listenerAccess.readFrom("entriesCount"));
+    Object appliedAt0 = resultAccess.readFrom("appliedAt", 0);
+    assertNotNull(appliedAt0);
+    assertEquals(Test1Happened.class, appliedAt0.getClass());
+    Entry<String> appendeAt0 = listenerAccess.readFrom("appendedAt", 0);
+    assertNotNull(appendeAt0);
+    assertEquals(Test1Happened.class.getName(), appendeAt0.type);
+    assertFalse(resultAccess.readFrom("tested1"));
   }
 
   @Test
   public void testThatCommandEmits() {
-    result.until = TestUntil.happenings(1);
+    final AccessSafely resultAccess = result.afterCompleting(1);
+    final AccessSafely listenerAccess = listener.afterCompleting(1);
+
     entity.doTest1();
-    result.until.completes();
-    assertTrue(result.tested1);
-    assertFalse(result.tested2);
-    assertEquals(1, result.applied.size());
-    assertEquals(1, listener.entries.size());
-    assertEquals(Test1Happened.class, result.applied.get(0).getClass());
-    assertEquals(Test1Happened.class.getName(), listener.entries.get(0).type);
-    result.until = TestUntil.happenings(1);
+    
+    assertTrue(resultAccess.readFrom("tested1"));
+    assertFalse(resultAccess.readFrom("tested2"));
+    assertEquals(1, (int) resultAccess.readFrom("appliedCount"));
+    assertEquals(1, (int) listenerAccess.readFrom("entriesCount"));
+    Object appliedAt0 = resultAccess.readFrom("appliedAt", 0);
+    assertNotNull(appliedAt0);
+    assertEquals(Test1Happened.class, appliedAt0.getClass());
+    Entry<String> appendeAt0 = listenerAccess.readFrom("appendedAt", 0);
+    assertNotNull(appendeAt0);
+    assertEquals(Test1Happened.class.getName(), appendeAt0.type);
+    
+    final AccessSafely resultAccess2 = result.afterCompleting(1);
+    final AccessSafely listenerAccess2 = listener.afterCompleting(1);
+    
     entity.doTest2();
-    result.until.completes();
-    assertEquals(2, result.applied.size());
-    assertEquals(2, listener.entries.size());
-    assertEquals(Test2Happened.class, result.applied.get(1).getClass());
-    assertEquals(Test2Happened.class.getName(), listener.entries.get(1).type);
+    
+    assertEquals(2, (int) resultAccess2.readFrom("appliedCount"));
+    assertEquals(2, (int) listenerAccess.readFrom("entriesCount"));
+    Object appliedAt1 = resultAccess2.readFrom("appliedAt", 1);
+    assertNotNull(appliedAt1);
+    assertEquals(Test2Happened.class, appliedAt1.getClass());
+    Entry<String> appendeAt1 = listenerAccess2.readFrom("appendedAt", 1);
+    assertNotNull(appendeAt1);
+    assertEquals(Test2Happened.class.getName(), appendeAt1.type);
   }
 
   @Test
   public void testThatOutcomeCompletes() {
-    result.until = TestUntil.happenings(1);
+    final AccessSafely resultAccess = result.afterCompleting(1);
+    final AccessSafely listenerAccess = listener.afterCompleting(1);
+    
     entity.doTest1();
-    result.until.completes();
-    assertTrue(result.tested1);
-    assertFalse(result.tested3);
-    assertEquals(1, result.applied.size());
-    assertEquals(1, listener.entries.size());
-    assertEquals(Test1Happened.class, result.applied.get(0).getClass());
-    assertEquals(Test1Happened.class.getName(), listener.entries.get(0).type);
-    result.until = TestUntil.happenings(2);
+    
+    assertTrue(resultAccess.readFrom("tested1"));
+    assertFalse(resultAccess.readFrom("tested3"));
+    assertEquals(1, (int) resultAccess.readFrom("appliedCount"));
+    assertEquals(1, (int) listenerAccess.readFrom("entriesCount"));
+    Object appliedAt0 = resultAccess.readFrom("appliedAt", 0);
+    assertNotNull(appliedAt0);
+    assertEquals(Test1Happened.class, appliedAt0.getClass());
+    Entry<String> appendeAt0 = listenerAccess.readFrom("appendedAt", 0);
+    assertNotNull(appendeAt0);
+    assertEquals(Test1Happened.class.getName(), appendeAt0.type);
+    
+    final AccessSafely resultAccess2 = result.afterCompleting(2);
+    final AccessSafely listenerAccess2 = listener.afterCompleting(1);
+    
     entity.doTest3().andThenConsume(greeting -> {
       assertEquals("hello", greeting);
-      result.until.happened();
     });
-    result.until.completes();
-    assertEquals(2, result.applied.size());
-    assertEquals(2, listener.entries.size());
-    assertEquals(Test3Happened.class, result.applied.get(1).getClass());
-    assertEquals(Test3Happened.class.getName(), listener.entries.get(1).type);
+    
+    assertEquals(2, (int) resultAccess2.readFrom("appliedCount"));
+    assertEquals(2, (int) listenerAccess2.readFrom("entriesCount"));
+    Object appliedAt1 = resultAccess2.readFrom("appliedAt", 1);
+    assertNotNull(appliedAt1);
+    assertEquals(Test3Happened.class, appliedAt1.getClass());
+    Entry<String> appendeAt1 = listenerAccess.readFrom("appendedAt", 1);
+    assertNotNull(appendeAt1);
+    assertEquals(Test3Happened.class.getName(), appendeAt1.type);
   }
 
   @Before

--- a/src/test/java/io/vlingo/lattice/model/sourcing/Result.java
+++ b/src/test/java/io/vlingo/lattice/model/sourcing/Result.java
@@ -7,15 +7,38 @@
 
 package io.vlingo.lattice.model.sourcing;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import io.vlingo.actors.testkit.TestUntil;
+import io.vlingo.actors.testkit.AccessSafely;
 
 public class Result {
-  public List<Object> applied = new ArrayList<>();
-  public boolean tested1;
-  public boolean tested2;
-  public boolean tested3;
-  public TestUntil until = TestUntil.happenings(0);
+  private AccessSafely access;
+  private CopyOnWriteArrayList<Object> applied = new CopyOnWriteArrayList<>();
+  private AtomicBoolean tested1;
+  private AtomicBoolean tested2;
+  private AtomicBoolean tested3;
+  
+  public AccessSafely access() {
+    return access;
+  }
+  
+  public AccessSafely afterCompleting(final int times) {
+    access = AccessSafely
+      .afterCompleting(times)
+      
+      .writingWith("applied", (Object obj) -> { System.out.println("Result WRITE applied"); applied.add(obj);})
+      .readingWith("applied", () -> applied)
+      .readingWith("appliedCount", () -> applied.size())
+      .readingWith("appliedAt", (Integer index) -> applied.get(index))
+      
+      .writingWith("tested1", (Boolean trueOrFalse) -> { System.out.println("Result WRITE tested1"); tested1.set(trueOrFalse);})
+      .readingWith("tested1", () -> tested1)
+      .writingWith("tested2", (Boolean trueOrFalse) -> { System.out.println("Result WRITE tested2"); tested2.set(trueOrFalse);})
+      .readingWith("tested2", () -> tested2)
+      .writingWith("tested3", (Boolean trueOrFalse) -> { System.out.println("Result WRITE tested3"); tested3.set(trueOrFalse);})
+      .readingWith("tested2", () -> tested2);
+
+    return access;
+  }
 }

--- a/src/test/java/io/vlingo/lattice/model/sourcing/TestCommandSourcedEntity.java
+++ b/src/test/java/io/vlingo/lattice/model/sourcing/TestCommandSourcedEntity.java
@@ -47,14 +47,12 @@ public class TestCommandSourcedEntity extends CommandSourced implements Entity {
   }
 
   private void applied1(final DoCommand1 command) {
-    result.tested1 = true;
-    result.applied.add(command);
-    result.until.happened();
+    result.access().writeUsing("tested1", true);
+    result.access().writeUsing("applied", command);
   }
 
   private void applied2(final DoCommand2 command) {
-    result.tested2 = true;
-    result.applied.add(command);
-    result.until.happened();
+    result.access().writeUsing("tested2", true);
+    result.access().writeUsing("applied", command);
   }
 }

--- a/src/test/java/io/vlingo/lattice/model/sourcing/TestEventSourcedEntity.java
+++ b/src/test/java/io/vlingo/lattice/model/sourcing/TestEventSourcedEntity.java
@@ -49,20 +49,17 @@ public class TestEventSourcedEntity extends EventSourced implements Entity {
   }
 
   private void applied1(final Test1Happened event) {
-    result.tested1 = true;
-    result.applied.add(event);
-    result.until.happened();
+    result.access().writeUsing("tested1", true);
+    result.access().writeUsing("applied", event);
   }
 
   private void applied2(final Test2Happened event) {
-    result.tested2 = true;
-    result.applied.add(event);
-    result.until.happened();
+    result.access().writeUsing("tested2", true);
+    result.access().writeUsing("applied", event);
   }
 
   private void applied3(final Test3Happened event) {
-    result.tested3 = true;
-    result.applied.add(event);
-    result.until.happened();
+    result.access().writeUsing("tested3", true);
+    result.access().writeUsing("applied", event);
   }
 }


### PR DESCRIPTION
@VaughnVernon CommandSourcedTest (either test method) hangs after the first `entity.doTest()` because the AccessSafely is never written. Before my changes, it certainly looks like the expectation was that the TestUntils would have happened once during that `doTest()` call (or maybe during the construction of the actor).

I see `doTest` get called on the entity proxy and it queues a `LocalMessage` but I never see that message get delivered to the `TestCommandSourcedEntity`.

I will keep debugging but maybe you'll see something obvious. Thanks