### PR TITLE
Moved registerMapper() outside the object store.  …

### DIFF
--- a/src/test/java/io/vlingo/lattice/model/object/EmployeeEntityTest.java
+++ b/src/test/java/io/vlingo/lattice/model/object/EmployeeEntityTest.java
@@ -69,7 +69,5 @@ public class EmployeeEntityTest {
             PersistentObjectMapper.with(Employee.class, new Object(), new Object()));
 
     registry.register(employeeInfo);
-
-    objectStore.registerMapper(employeeInfo.mapper);
   }
 }

--- a/src/test/java/io/vlingo/lattice/model/object/PersonEntityTest.java
+++ b/src/test/java/io/vlingo/lattice/model/object/PersonEntityTest.java
@@ -67,7 +67,5 @@ public class PersonEntityTest {
             PersistentObjectMapper.with(Person.class, new Object(), new Object()));
 
     registry.register(personInfo);
-
-    objectStore.registerMapper(personInfo.mapper);
   }
 }

--- a/src/test/java/io/vlingo/lattice/model/process/ObjectProcessTest.java
+++ b/src/test/java/io/vlingo/lattice/model/process/ObjectProcessTest.java
@@ -85,7 +85,6 @@ public class ObjectProcessTest {
             PersistentObjectMapper.with(StepCountObjectState.class, new Object(), new Object()));
 
     objectTypeRegistry.register(stepCountStateInfo);
-    objectStore.registerMapper(stepCountStateInfo.mapper);
 
     exchangeReceivers = new ExchangeReceivers();
     exchangeSender = new LocalExchangeSender(queue);


### PR DESCRIPTION
Created a interface for object store persistence: `ObjectStoreDelegate`.

Fix for https://github.com/vlingo/vlingo-symbio/issues/15.

**Depends on:** https://github.com/vlingo/vlingo-symbio/pull/16