### PR TITLE
Fixes issue with not found class when serialize / deserialize data

### DIFF
--- a/src/main/java/io/vlingo/actors/Grid.java
+++ b/src/main/java/io/vlingo/actors/Grid.java
@@ -164,6 +164,10 @@ public class Grid extends Stage implements GridRuntime {
     this.nodeId = nodeId;
   }
 
+  public ClassLoader worldLoader() {
+    return world().classLoader();
+  }
+
   //====================================
   // Internal implementation
   //====================================


### PR DESCRIPTION
This PR provides a fix for #23.

## Root cause

FST serializer uses default classloader from the config (Default one is a system classloader). Thus, when it comes to pars data 
```
public Class classForName(String clName, FSTConfiguration conf) throws ClassNotFoundException {
        if ( parent != null ) {
            return parent.classForName(clName,conf);
        }
        try {
            while (!classCacheLock.compareAndSet(false, true)) ;
            Class res = classCache.get(clName);
            if (res == null) {
                try {
                    res = Class.forName(clName, false, conf.getClassLoader());
```

`conf.getClassLoader()` returns a system one which has no clue about the `DynoClassLoader` created by `World`.
