### PR TITLE
Make sure the projection state is written before handling the next projectable

### DIFF
--- a/src/test/java/io/vlingo/lattice/model/projection/WarbleStateStoreProjection.java
+++ b/src/test/java/io/vlingo/lattice/model/projection/WarbleStateStoreProjection.java
@@ -30,7 +30,10 @@ public class WarbleStateStoreProjection extends StateStoreProjectionActor<Warble
 
   @Override
   protected Warble merge(final Warble previousData, final int previousVersion, final Warble currentData, final int currentVersion) {
-    return currentData;
+    if (previousData == null) {
+      return currentData;
+    }
+    return new Warble(currentData.name, currentData.type, currentData.count + previousData.count);
   }
 
   public static class Warble {


### PR DESCRIPTION
Currently, when handling multiple projectables dispatched one after another, the state isn't written quickly enough to be available for the next projectable.

The solution is to stow messages before the read and disperse them once the state was written.
