### PR TITLE
Generate distributable addresses with the GridAddressFactory

### DIFF
--- a/src/main/java/io/vlingo/actors/GridAddressFactory.java
+++ b/src/main/java/io/vlingo/actors/GridAddressFactory.java
@@ -39,6 +39,21 @@ public final class GridAddressFactory extends UUIDAddressFactory {
   }
 
   @Override
+  public Address unique() {
+    return this.from(super.unique().idString());
+  }
+
+  @Override
+  public Address uniqueWith(String name) {
+    return this.from(super.uniqueWith(name).idString(), name);
+  }
+
+  @Override
+  public Address uniquePrefixedWith(String prefixedWith) {
+    return new GridAddress(super.uniquePrefixedWith(prefixedWith).idTyped(), prefixedWith, true);
+  }
+
+  @Override
   public Address none() {
     return None;
   }

--- a/src/test/java/io/vlingo/actors/AddressTest.java
+++ b/src/test/java/io/vlingo/actors/AddressTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.UUID;
@@ -94,5 +95,18 @@ public class AddressTest {
     assertArrayEquals(ordered, reversed);
     Arrays.sort(ordered);
     assertArrayEquals(reversed, ordered);
+  }
+
+  @Test
+  public void testItCreatesDistributableAddresses() {
+    final AddressFactory addressFactory = new GridAddressFactory(IdentityGeneratorType.RANDOM);
+
+    final Address address = addressFactory.unique();
+    final Address namedAddress = addressFactory.uniqueWith("test-address");
+    final Address prefixedAddress = addressFactory.uniquePrefixedWith("test-prefix");
+
+    assertTrue(address.isDistributable());
+    assertTrue(namedAddress.isDistributable());
+    assertTrue(prefixedAddress.isDistributable());
   }
 }

--- a/src/test/java/io/vlingo/lattice/grid/GridActorOfTest.java
+++ b/src/test/java/io/vlingo/lattice/grid/GridActorOfTest.java
@@ -104,6 +104,7 @@ public class GridActorOfTest {
       final io.vlingo.cluster.model.Properties properties = ClusterProperties.oneNode();
 
       grid = Grid.start(world, properties, "node1");
+      grid.quorumAchieved();
   }
 
   @After


### PR DESCRIPTION
Currently, addresses generated by the `GridAddressFactory.unique*()` methods return an instance of the `UUIDAddress` instead of the `GridAddress`.

As a result, actors addressed with the grid address factory are not distributable.