### PR TITLE
Retry unacknowledged messages

### DIFF
--- a/src/main/java/io/vlingo/actors/InboundGridActorControl.java
+++ b/src/main/java/io/vlingo/actors/InboundGridActorControl.java
@@ -112,6 +112,15 @@ public class InboundGridActorControl extends Actor implements GridActorControl.I
                     address);
 
     actor.lifeCycle.environment.mailbox.send(actor, protocol, consumer, returns, representation);
+
+    if (GridActorOperations.isSuspendedForRelocation(actor)) {
+      // this case is happening when a message is retried on a different node and above actor is created 'on demand'
+      logger().debug("Resuming thunk found at {} with definition='{}'",
+              address,
+              actor.definition());
+
+      GridActorOperations.resumeFromRelocation(actor);
+    }
   }
 
   @Override

--- a/src/main/java/io/vlingo/actors/InboundGridActorControl.java
+++ b/src/main/java/io/vlingo/actors/InboundGridActorControl.java
@@ -7,24 +7,25 @@
 
 package io.vlingo.actors;
 
+import io.vlingo.common.SerializableConsumer;
+import io.vlingo.lattice.grid.application.GridActorControl;
+import io.vlingo.lattice.grid.application.message.Answer;
+import io.vlingo.lattice.grid.application.message.UnAckMessage;
+import io.vlingo.wire.node.Id;
+
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
-import io.vlingo.common.SerializableConsumer;
-import io.vlingo.lattice.grid.application.GridActorControl;
-import io.vlingo.lattice.grid.application.message.Answer;
-import io.vlingo.wire.node.Id;
-
 public class InboundGridActorControl extends Actor implements GridActorControl.Inbound {
 
   private final GridRuntime gridRuntime;
 
-  private final Function<UUID, Returns<?>> correlation;
+  private final Function<UUID, UnAckMessage> correlation;
 
 
-  public InboundGridActorControl(final GridRuntime gridRuntime, final Function<UUID, Returns<?>> correlation) {
+  public InboundGridActorControl(final GridRuntime gridRuntime, final Function<UUID, UnAckMessage> correlation) {
     this.gridRuntime = gridRuntime;
     this.correlation = correlation;
   }
@@ -33,7 +34,7 @@ public class InboundGridActorControl extends Actor implements GridActorControl.I
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public <T> void answer(final Id receiver, final Id sender, final Answer<T> answer) {
     logger().debug("GRID: Processing application message: Answer");
-    final Returns<Object> clientReturns = (Returns<Object>) correlation.apply(answer.correlationId);
+    final Returns<Object> clientReturns = correlation.apply(answer.correlationId).getReturns();
     if (clientReturns == null) {
       logger().warn("GRID: Answer from {} for Returns with {} didn't match a Returns on this node!", sender, answer.correlationId);
       return;
@@ -153,9 +154,9 @@ public class InboundGridActorControl extends Actor implements GridActorControl.I
     private static final long serialVersionUID = 1494058617174306163L;
 
     private final GridRuntime gridRuntime;
-    private final Function<UUID, Returns<?>> correlation;
+    private final Function<UUID, UnAckMessage> correlation;
 
-    public InboundGridActorControlInstantiator(final GridRuntime gridRuntime, final Function<UUID, Returns<?>> correlation) {
+    public InboundGridActorControlInstantiator(final GridRuntime gridRuntime, final Function<UUID, UnAckMessage> correlation) {
       this.gridRuntime = gridRuntime;
       this.correlation = correlation;
     }

--- a/src/main/java/io/vlingo/lattice/grid/GridNode.java
+++ b/src/main/java/io/vlingo/lattice/grid/GridNode.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import io.vlingo.lattice.grid.application.message.UnAckMessage;
 import org.nustaq.serialization.FSTConfiguration;
 
 import io.vlingo.actors.Definition;
@@ -40,7 +41,7 @@ import io.vlingo.wire.node.Id;
 import io.vlingo.wire.node.Node;
 
 public class GridNode extends ClusterApplicationAdapter {
-  private static final Map<UUID, Returns<?>> correlation = new HashMap<>();
+  private static final Map<UUID, UnAckMessage> correlation = new HashMap<>();
 
   private AttributesProtocol client;
   private final GridRuntime gridRuntime;

--- a/src/main/java/io/vlingo/lattice/grid/application/message/Answer.java
+++ b/src/main/java/io/vlingo/lattice/grid/application/message/Answer.java
@@ -1,3 +1,10 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.lattice.grid.application.message;
 
 import io.vlingo.wire.node.Id;

--- a/src/main/java/io/vlingo/lattice/grid/application/message/Decoder.java
+++ b/src/main/java/io/vlingo/lattice/grid/application/message/Decoder.java
@@ -1,3 +1,10 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.lattice.grid.application.message;
 
 public interface Decoder {

--- a/src/main/java/io/vlingo/lattice/grid/application/message/Encoder.java
+++ b/src/main/java/io/vlingo/lattice/grid/application/message/Encoder.java
@@ -1,3 +1,10 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.lattice.grid.application.message;
 
 public interface Encoder {

--- a/src/main/java/io/vlingo/lattice/grid/application/message/Forward.java
+++ b/src/main/java/io/vlingo/lattice/grid/application/message/Forward.java
@@ -1,3 +1,10 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.lattice.grid.application.message;
 
 import io.vlingo.wire.node.Id;

--- a/src/main/java/io/vlingo/lattice/grid/application/message/Message.java
+++ b/src/main/java/io/vlingo/lattice/grid/application/message/Message.java
@@ -1,3 +1,10 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.lattice.grid.application.message;
 
 import io.vlingo.wire.node.Id;

--- a/src/main/java/io/vlingo/lattice/grid/application/message/Relocate.java
+++ b/src/main/java/io/vlingo/lattice/grid/application/message/Relocate.java
@@ -1,3 +1,10 @@
+
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.lattice.grid.application.message;
 
 import io.vlingo.actors.Address;

--- a/src/main/java/io/vlingo/lattice/grid/application/message/Start.java
+++ b/src/main/java/io/vlingo/lattice/grid/application/message/Start.java
@@ -1,3 +1,10 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.lattice.grid.application.message;
 
 import io.vlingo.actors.Address;

--- a/src/main/java/io/vlingo/lattice/grid/application/message/UnAckMessage.java
+++ b/src/main/java/io/vlingo/lattice/grid/application/message/UnAckMessage.java
@@ -1,0 +1,39 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.lattice.grid.application.message;
+
+import io.vlingo.actors.Returns;
+import io.vlingo.wire.node.Id;
+
+/**
+ * This class represents an unacknowledged message which has been sent to recipient.
+ */
+public class UnAckMessage {
+    private final Id receiver;
+    private final Returns<?> returns;
+    private final Deliver<?> message;
+
+    public UnAckMessage(Id receiver, Returns<?> returns, Deliver<?> message) {
+        this.receiver = receiver;
+        this.returns = returns;
+        this.message = message;
+    }
+
+    public Id getReceiver() {
+        return receiver;
+    }
+
+    @SuppressWarnings("unchecked")
+    public Returns<Object> getReturns() {
+        return (Returns<Object>) returns;
+    }
+
+    public Deliver<?> getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/io/vlingo/lattice/grid/application/message/Visitor.java
+++ b/src/main/java/io/vlingo/lattice/grid/application/message/Visitor.java
@@ -1,3 +1,10 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.lattice.grid.application.message;
 
 import io.vlingo.wire.node.Id;


### PR DESCRIPTION
Retry unanswered messages initially delivered to a node which has just left the cluster.
This PR covers the cases where unanswered messages are redelivered either locally or remotely to a new node.
This PR guarantees that ongoing messages processed by a crushed node are redelivered onto another node from the cluster.